### PR TITLE
Increase timeout for nft command call

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+network-manager (1.42.4-1~bpo11+1-wb103) bullseye-backports; urgency=medium
+
+  * Increase timeout for nft command call
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 22 Jan 2025 17:00:00 +0400
+
 network-manager (1.42.4-1~bpo11+1-wb102) bullseye-backports; urgency=medium
 
   * Add arm64 build, no functional changes

--- a/src/core/nm-firewall-utils.c
+++ b/src/core/nm-firewall-utils.c
@@ -622,7 +622,7 @@ nm_firewall_nft_call(GBytes             *stdin_buf,
                                    call_data);
 
     call_data->timeout_source =
-        nm_g_source_attach(nm_g_timeout_source_new((NM_SHUTDOWN_TIMEOUT_1500_MSEC * 2) / 3,
+        nm_g_source_attach(nm_g_timeout_source_new((NM_SHUTDOWN_TIMEOUT_MAX_MSEC * 2) / 3,
                                                    G_PRIORITY_DEFAULT,
                                                    _fw_nft_call_timeout_cb,
                                                    call_data,


### PR DESCRIPTION
Before: `(NM_SHUTDOWN_TIMEOUT_1500_MSEC * 2) / 3` is 1s
After: `(NM_SHUTDOWN_TIMEOUT_MAX_MSEC * 2) / 3` is ~3s

During boot, the first call to nft often takes more than 1s, resulting in the table not being created:
```sh
[1737577101.1624] firewall: nft: call command: [ 'add table ip nm-shared-eth0\012flush table ip nm-shared-eth0\012add chain ip nm-shared-eth0 nat_postrouting { type nat hook postrouting priority 100; policy accept; };\012add rule ip nm-shared-eth0 nat_postrouting ip saddr 10.42.0.0/24 ip daddr != 10.42.0.0/24 masquerade;\012add chain ip nm-shared-eth0 filter_forward { type filter hook forward priority 0; policy accept; };\012add rule ip nm-shared-eth0 filter_forward ip daddr 10.42.0.0/24 oifname "eth0" ct state { established, related } accept;\012add rule ip nm-shared-eth0 filter_forward ip saddr 10.42.0.0/24 iifname "eth0" accept;\012add rule ip nm-shared-eth0 filter_forward iifname "eth0" oifname "eth0" accept;\012add rule ip nm-shared-eth0 filter_forward iifname "eth0" reject;\012add rule ip nm-shared-eth0 filter_forward oifname "eth0" reject;\012' ]
[1737577101.2168] firewall: nft[1785]: communicate with nft
[1737577102.2188] firewall: nft[1785]: cancel operation after timeout
[1737577102.6783] firewall: nft: call command: [ 'add table ip nm-shared-wlan0\012flush table ip nm-shared-wlan0\012add chain ip nm-shared-wlan0 nat_postrouting { type nat hook postrouting priority 100; policy accept; };\012add rule ip nm-shared-wlan0 nat_postrouting ip saddr 192.168.42.0/24 ip daddr != 192.168.42.0/24 masquerade;\012add chain ip nm-shared-wlan0 filter_forward { type filter hook forward priority 0; policy accept; };\012add rule ip nm-shared-wlan0 filter_forward ip daddr 192.168.42.0/24 oifname "wlan0" ct state { established, related } accept;\012add rule ip nm-shared-wlan0 filter_forward ip saddr 192.168.42.0/24 iifname "wlan0" accept;\012add rule ip nm-shared-wlan0 filter_forward iifname "wlan0" oifname "wlan0" accept;\012add rule ip nm-shared-wlan0 filter_forward iifname "wlan0" reject;\012add rule ip nm-shared-wlan0 filter_forward oifname "wlan0" reject;\012' ]
[1737577102.7018] firewall: nft[2201]: communicate with nft
[1737577102.8017] firewall: nft[2201]: command successful
[1737577104.4199] firewall: nft: call command: [ 'add table ip nm-shared-dbg0\012flush table ip nm-shared-dbg0\012add chain ip nm-shared-dbg0 nat_postrouting { type nat hook postrouting priority 100; policy accept; };\012add rule ip nm-shared-dbg0 nat_postrouting ip saddr 10.200.200.0/30 ip daddr != 10.200.200.0/30 masquerade;\012add chain ip nm-shared-dbg0 filter_forward { type filter hook forward priority 0; policy accept; };\012add rule ip nm-shared-dbg0 filter_forward ip daddr 10.200.200.0/30 oifname "dbg0" ct state { established, related } accept;\012add rule ip nm-shared-dbg0 filter_forward ip saddr 10.200.200.0/30 iifname "dbg0" accept;\012add rule ip nm-shared-dbg0 filter_forward iifname "dbg0" oifname "dbg0" accept;\012add rule ip nm-shared-dbg0 filter_forward iifname "dbg0" reject;\012add rule ip nm-shared-dbg0 filter_forward oifname "dbg0" reject;\012' ]
[1737577104.4325] firewall: nft[2646]: communicate with nft
[1737577104.4497] firewall: nft[2646]: command successful
[1737577119.5656] firewall: nft: call command: [ 'add table ip nm-shared-eth1\012flush table ip nm-shared-eth1\012add chain ip nm-shared-eth1 nat_postrouting { type nat hook postrouting priority 100; policy accept; };\012add rule ip nm-shared-eth1 nat_postrouting ip saddr 10.42.1.0/24 ip daddr != 10.42.1.0/24 masquerade;\012add chain ip nm-shared-eth1 filter_forward { type filter hook forward priority 0; policy accept; };\012add rule ip nm-shared-eth1 filter_forward ip daddr 10.42.1.0/24 oifname "eth1" ct state { established, related } accept;\012add rule ip nm-shared-eth1 filter_forward ip saddr 10.42.1.0/24 iifname "eth1" accept;\012add rule ip nm-shared-eth1 filter_forward iifname "eth1" oifname "eth1" accept;\012add rule ip nm-shared-eth1 filter_forward iifname "eth1" reject;\012add rule ip nm-shared-eth1 filter_forward oifname "eth1" reject;\012' ]
[1737577119.5719] firewall: nft[3208]: communicate with nft
[1737577119.5816] firewall: nft[3208]: command successful
```